### PR TITLE
Added script to print changes in assignment map

### DIFF
--- a/print_changes_in_assignment_in_groups.py
+++ b/print_changes_in_assignment_in_groups.py
@@ -1,0 +1,74 @@
+import argparse
+import glob
+import os
+
+import numpy as np
+import torch
+
+from modules.flgc import Flgc2d
+
+
+def get_epoch(checkpoint_path):
+    return int(checkpoint_path.split('net_epoch_')[1].split('.pth')[0])
+
+
+def get_flgc_layer(net, needed_layer_id):
+    layer_id = -1
+    for module in net.modules():
+        if isinstance(module, Flgc2d):
+            layer_id += 1
+            if layer_id == needed_layer_id:
+                return module
+    raise IndexError('No flgc layer with such id, possible range: [{}, {}]'.format(0, layer_id))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Allows to track changes in assignment of input channels/filters in groups')
+    parser.add_argument('--checkpoints-dir', type=str, required=True, help='path to the directory with model checkpoints')
+    parser.add_argument('--layer-id', type=int, default=0, help='flgc layer id to print statistic')
+    parser.add_argument('--track-filters', action='store_true', default=False, help='track changes in assignment of filters in groups')
+    args = parser.parse_args()
+
+    checkpoint_paths = glob.glob(os.path.join(args.checkpoints_dir, 'net_epoch_*.pth'))
+    checkpoint_paths = sorted(checkpoint_paths, key=lambda path: get_epoch(path))
+
+    net = torch.load(checkpoint_paths[0], map_location='cpu')['net']
+    module = get_flgc_layer(net, args.layer_id)
+    rows_names = ['{:^13}'.format('epoch {}'.format(get_epoch(checkpoint_paths[0])))]
+    assignment_map_to_check = module.out_channels_in_group_assignment_map if args.track_filters else module.in_channels_in_group_assignment_map
+    previous_assignment_map = module.binarize(torch.softmax(assignment_map_to_check, dim=1)).detach().data.cpu().numpy()
+    channels_per_group = np.sum(previous_assignment_map, axis=0).astype(np.int32)
+    cols_names = ['{:^13}'.format('group {}'.format(group_id)) for group_id in range(len(channels_per_group))]
+    cols_names = ['{:^13}'.format('')] + cols_names + ['{:^13}'.format('Total diff.')]
+    stats = [[] for _ in range(len(channels_per_group) + 1)]
+    for group_id, channels_num in enumerate(channels_per_group):
+        stats[group_id].append('{:^13}'.format('{:+d}/{:+d}/{:d}'.format(0, 0, channels_num)))
+    stats[-1].append('{:^13}'.format(0))
+    
+    for checkpoint_path in checkpoint_paths[1:]:
+        rows_names.append('{:^13}'.format('epoch {}'.format(get_epoch(checkpoint_path))))
+        net = torch.load(checkpoint_path, map_location='cpu')['net']
+        module = get_flgc_layer(net, args.layer_id)
+        assignment_map_to_check = module.out_channels_in_group_assignment_map if args.track_filters else module.in_channels_in_group_assignment_map
+        assignment_map = module.binarize(torch.softmax(assignment_map_to_check, dim=1)).detach().data.cpu().numpy()
+        assignment_map_diff = assignment_map - previous_assignment_map
+        deleted_channels_per_group = assignment_map_diff.copy()
+        deleted_channels_per_group[deleted_channels_per_group > 0] = 0
+        deleted_channels_per_group = np.sum(deleted_channels_per_group, axis=0).astype(np.int32)
+        added_channels_per_group = assignment_map_diff.copy()
+        added_channels_per_group[added_channels_per_group < 0] = 0
+        added_channels_per_group = np.sum(added_channels_per_group, axis=0).astype(np.int32)
+        channels_per_group = np.sum(assignment_map, axis=0).astype(np.int32)
+        for group_id, channels_num in enumerate(channels_per_group):
+            stats[group_id].append('{:^13}'.format('{:+d}/{:+d}/{:d}'.format(deleted_channels_per_group[group_id],
+                                                                             added_channels_per_group[group_id], channels_num)))
+        stats[-1].append('{:^13}'.format(np.sum(np.abs(assignment_map_diff).astype(np.int32))))
+        previous_assignment_map = assignment_map
+    for col_name in cols_names:
+        print(col_name, end='')
+    print('\n')
+    for row_id, row_name in enumerate(rows_names):
+        print(row_name, end='')
+        for group_stat in stats:
+            print(group_stat[row_id], end='')
+        print('\n')


### PR DESCRIPTION
The script helps to track changes in assignment in groups of input channels/filters. The dynamic is below: for particular epoch number of `deleted/added/total` channels per group is shown, in comparison with the previous epoch. This statistic is for input channels in groups assignment for 0<sup>th</sup> layer (`python print_changes_in_assignment_in_groups.py --checkpoints-dir default_checkpoints/ --layer-id 0`):
```
                group 0      group 1      group 2      group 3      group 4      group 5      group 6      group 7    Total diff. 

   epoch 0      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 1      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 2      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 3      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 4      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 5      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

   epoch 6      +0/+0/7      -1/+0/5      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+1/4      +0/+0/4         2      

   epoch 7      +0/+0/7      +0/+0/5      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/4      +0/+0/4         0      

   epoch 8      +0/+0/7      +0/+1/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      -1/+0/3      +0/+0/4         2      

   epoch 9      +0/+0/7      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/4         0      

  epoch 80      +0/+0/8      +0/+0/6      +0/+0/1      +0/+0/3      +0/+0/7      +0/+0/1      +0/+0/3      +0/+0/3         0
```
for 16<sup>th</sup> layer:
```
                group 0      group 1      group 2      group 3      group 4      group 5      group 6      group 7    Total diff. 

   epoch 0     +0/+0/112    +0/+0/126    +0/+0/115    +0/+0/113    +0/+0/127    +0/+0/117    +0/+0/121    +0/+0/129        0      

   epoch 1     +0/+0/112    +0/+0/126    +0/+0/115    -1/+0/112    +0/+1/128    +0/+0/117    +0/+0/121    +0/+0/129        2      

   epoch 2     +0/+0/112    +0/+0/126    +0/+0/115    -1/+0/111    +0/+0/128    +0/+0/117    +0/+0/121    +0/+1/130        2      

   epoch 3     +0/+0/112    +0/+0/126    +0/+0/115    +0/+1/112    -1/+0/127    +0/+0/117    +0/+0/121    +0/+0/130        2      

   epoch 4     +0/+0/112    +0/+0/126    +0/+0/115    -1/+0/111    +0/+1/128    +0/+0/117    +0/+0/121    +0/+0/130        2      

   epoch 5     +0/+0/112    +0/+0/126    +0/+0/115    +0/+1/112    -1/+0/127    +0/+0/117    +0/+0/121    +0/+0/130        2      

   epoch 6     -1/+0/111    +0/+0/126    +0/+0/115    -2/+0/110    +0/+1/128    +0/+2/119    +0/+0/121    +0/+0/130        6      

   epoch 7     +0/+1/112    +0/+0/126    +0/+0/115    +0/+3/113    -1/+0/127    -2/+0/117    +0/+0/121    -1/+0/129        8      

   epoch 8     +0/+0/112    +0/+0/126    +0/+1/116    -1/+0/112    +0/+0/127    +0/+0/117    +0/+0/121    -1/+1/129        4      

   epoch 9     +0/+0/112    +0/+0/126    -1/+0/115    -2/+1/111    +0/+1/128    +0/+1/118    +0/+0/121    -1/+1/129        8      

  epoch 80     +0/+1/112    -1/+1/126    +0/+0/116    +0/+1/111    +0/+0/127    -1/+0/117    -2/+0/121    +0/+1/130        8
```
and for output filters of 16<sup>th</sup> layer:
```
                group 0      group 1      group 2      group 3      group 4      group 5      group 6      group 7    Total diff. 

   epoch 0     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 1     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 2     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 3     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 4     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 5     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 6     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 7     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 8     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

   epoch 9     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0      

  epoch 80     +0/+0/37     +0/+0/37     +0/+0/43     +0/+0/53     +0/+0/36     +0/+0/37     +0/+0/37     +0/+0/40         0
```

Thus, input channels hardly change their group, but filters do not change their initial random assignment in groups at all.
